### PR TITLE
This patch ensures that a proper error message is return to the

### DIFF
--- a/lib/viki/core/error_response.rb
+++ b/lib/viki/core/error_response.rb
@@ -6,8 +6,8 @@ module Viki::Core
     attr_accessor :error, :vcode, :status, :url, :json, :body, :details
 
     def initialize(body, status, url)
-      @body = body
       @status = status.to_i
+      @body = entity_too_large? ? set_413_body : body
       @url = url
       begin
         @json = Oj.load(@body.to_s, mode: :compat, symbol_keys: false)
@@ -45,6 +45,14 @@ module Viki::Core
 
     def server_error?
       @status >= 500 && @status < 600
+    end
+
+    def entity_too_large?
+      @status == 413
+    end
+
+    def set_413_body
+      Oj.dump({"error" => "Entity too large", "details" => "client_max_body side exceeded", "vcode" => 0})
     end
   end
 end

--- a/spec/viki/core/error_response_spec.rb
+++ b/spec/viki/core/error_response_spec.rb
@@ -38,4 +38,16 @@ describe Viki::Core::ErrorResponse do
     its(:client_error?) { should == false }
     its(:server_error?) { should == true }
   end
+
+  context 'entity too large' do
+    let(:status) { 413 }
+
+    its(:status) { should == 413 }
+    its(:entity_too_large?) { should == true }
+    its(:not_found?) { should == false }
+    its(:invalid_token?) { should == false }
+    its(:client_error?) { should == true }
+    its(:server_error?) { should == false }
+    its(:error) { should == 'Entity too large'}
+  end
 end


### PR DESCRIPTION
client on http 413 error.

Http status 413 error does not return any error string because
the body is empty.