### PR TITLE
Feature/roleless public writing

### DIFF
--- a/lib/viki/core/fetcher.rb
+++ b/lib/viki/core/fetcher.rb
@@ -15,7 +15,12 @@ module Viki::Core
       super && return if @url.include?("nocache=true")
       super && return unless Viki.cache && !cacheable.empty?
 
-      cached = Viki.cache.get(cache_key(url))
+      public_cache_key = cache_key(url, true)
+      private_cache_key = cache_key(url, false)
+      cached = if Viki.cache.exists(private_cache_key)
+              then Viki.cache.get(private_cache_key)
+              else Viki.cache.get(public_cache_key)
+              end
       if cached
         begin
           parsed_body = Oj.load(cached, mode: :compat, symbol_keys: false)

--- a/lib/viki/leaderboard.rb
+++ b/lib/viki/leaderboard.rb
@@ -1,5 +1,4 @@
 class Viki::Leaderboard < Viki::Core::Base
-
+  cacheable
   path "/leaderboards/:type"
-
 end

--- a/spec/viki/core/fetcher_spec.rb
+++ b/spec/viki/core/fetcher_spec.rb
@@ -99,6 +99,10 @@ describe Viki::Core::Fetcher do
             self[k]
           end
 
+          def c.exists(k)
+            self.key?(k)
+          end
+
           def c.expire(k, s)
           end
         }
@@ -209,6 +213,10 @@ describe Viki::Core::Fetcher do
               self["cache-seconds"] = time
             end
 
+            def c.exists(k)
+              self.key?(k)
+            end
+
             def c.get(k)
               self[k]
             end
@@ -293,6 +301,10 @@ describe Viki::Core::Fetcher do
           {}.tap { |c|
             def c.setex(k, time, v)
               self["cache-seconds"] = time
+            end
+
+            def c.exists(k)
+              self.key?(k)
             end
 
             def c.get(k)

--- a/spec/viki/core/fetcher_spec.rb
+++ b/spec/viki/core/fetcher_spec.rb
@@ -196,7 +196,7 @@ describe Viki::Core::Fetcher do
 
       describe "Cache-Control header (for Fetcher taking in JSON)" do
         let(:cacheSeconds) { 5 }
-        let(:fetchUrl) { "http://one.two/three" }
+        let(:fetchUrl) { "http://one.two/three?token=4567_89" }
         let(:fetcher) {
           Viki::Core::Fetcher.new(fetchUrl, nil, {}, "json",
                                   { cache_seconds: cacheSeconds })
@@ -205,6 +205,7 @@ describe Viki::Core::Fetcher do
         let(:newCache) {
           {}.tap { |c|
             def c.setex(key, time, value)
+              self["cache-key"] = key
               self["cache-seconds"] = time
             end
 
@@ -250,6 +251,32 @@ describe Viki::Core::Fetcher do
 
           fetcher.queue do
             newCache["cache-seconds"].should == cacheSeconds
+          end
+        end
+
+        it "omit role trail in cache key when the resource is public" do
+          Viki.stub(:cache) { newCache }
+          stub_request("get", fetchUrl).to_return(
+            body: Oj.dump(content, mode: :compat),
+            status: 200,
+            headers: { "Cache-Control" => "public, max-age=1793" }
+          )
+
+          fetcher.queue do
+            newCache["cache-key"].should == "viki-api-gem./three"
+          end
+        end
+
+        it "sets role trail in cache key when the resource is private" do
+          Viki.stub(:cache) { newCache }
+          stub_request("get", fetchUrl).to_return(
+            body: Oj.dump(content, mode: :compat),
+            status: 200,
+            headers: { "Cache-Control" => "private, max-age=1793" }
+          )
+
+          fetcher.queue do
+            newCache["cache-key"].should == "viki-api-gem./three-@role=89"
           end
         end
       end


### PR DESCRIPTION
Context of PR is to separate caching scenarios for public and private "Cache-Control" headers, and deprecate the use of "user_role" if it is meant for public cache

This should help to optimise the amount of repeated calls and storage required for every single role type possible (from now and added in the future)