### PR TITLE
Added logic to disable ssl when required

### DIFF
--- a/lib/viki/core/base.rb
+++ b/lib/viki/core/base.rb
@@ -47,7 +47,10 @@ module Viki::Core
       end
 
       def use_ssl
-        @_ssl = true
+        # Only during development, we set this config to ensure that we can test
+        # individual classes inheriting from this class without ssl being
+        # enabled individually
+        @_ssl = !Viki.force_http_protocol
       end
 
       def is_ssl_enabled?

--- a/spec/viki/core/base_spec.rb
+++ b/spec/viki/core/base_spec.rb
@@ -331,9 +331,25 @@ describe Viki::Core::Base do
         end
       end
 
-      it 'use_ssl is called' do
-        Viki::Core::Base.use_ssl
-        expect(Viki::Core::Base.is_ssl_enabled?).to eq true
+      describe 'use_ssl is called' do
+        it 'without any special config' do
+          Viki::Core::Base.use_ssl
+          expect(Viki::Core::Base.is_ssl_enabled?).to eq true
+        end
+
+        it 'with force_class_http_protocol disabled' do
+          Viki.should_receive(:force_http_protocol).and_return(false)
+          Viki::Core::Base.use_ssl
+          expect(Viki::Core::Base._ssl).to eq true
+          expect(Viki::Core::Base.is_ssl_enabled?).to eq true
+        end
+
+        it 'with force_class_http_protocol enabled' do
+          Viki.should_receive(:force_http_protocol).and_return(true)
+          Viki::Core::Base.use_ssl
+          expect(Viki::Core::Base._ssl).to eq false
+          expect(Viki::Core::Base.is_ssl_enabled?).to eq false
+        end
       end
 
       it 'use_ssl is not called' do

--- a/spec/viki_spec.rb
+++ b/spec/viki_spec.rb
@@ -71,6 +71,60 @@ describe Viki do
       expect(Viki.is_ssl_enabled?).to eq true
     end
 
+    describe 'initializes with ssl option' do
+      it 'and development - forced http protocol as true' do
+        ENV.stub(:fetch).with('RAILS_ENV', 'no-environment').and_return('development')
+
+        Viki.configure do |c|
+          c.ssl = true
+          c.force_http_protocol = true
+        end
+
+        expect(Viki.is_ssl_enabled?).to eq false
+      end
+
+      it 'and development - forced http protocol as false' do
+        ENV.stub(:fetch).with('RAILS_ENV', 'no-environment').and_return('development')
+
+        Viki.configure do |c|
+          c.ssl = true
+          c.force_http_protocol = false
+        end
+
+        expect(Viki.is_ssl_enabled?).to eq true
+      end
+
+      it 'and production - forced http protocol as true' do
+        ENV.stub(:fetch).with('RAILS_ENV', 'no-environment').and_return('production')
+
+        Viki.configure do |c|
+          c.ssl = true
+          c.force_http_protocol = true
+        end
+
+        expect(Viki.is_ssl_enabled?).to eq true
+      end
+
+      it 'and production - forced http protocol as false' do
+        ENV.stub(:fetch).with('RAILS_ENV', 'no-environment').and_return('production')
+
+        Viki.configure do |c|
+          c.ssl = true
+          c.force_http_protocol = false
+        end
+
+        expect(Viki.is_ssl_enabled?).to eq true
+      end
+    end
+
+    it 'initializes without ssl option' do
+      Viki.configure do |c|
+        c.ssl = false
+      end
+
+      expect(Viki.is_ssl_enabled?).to eq false
+    end
+
     it 'initializes without ssl option' do
       Viki.configure do |c|
         c.ssl = false


### PR DESCRIPTION
Context of this PR is to allow developers to disable ssl protocol entirely in development mode.

This is useful for testing purposes, but it should not be enabled in production which affects how I have implemented it