### PR TITLE
Remove cacheable option on Viki::Thread

### DIFF
--- a/lib/viki/thread.rb
+++ b/lib/viki/thread.rb
@@ -1,5 +1,4 @@
 class Viki::Thread < Viki::Core::Base
-  cacheable
   BULK_CREATE='bulk_create'
   path "/users/:user_id/threads"
   path "/users/:user_id/threads/bulk_create", name: BULK_CREATE


### PR DESCRIPTION
 - Threads are part of UGC, hence the indeterministic availability of the content. Until we figure out a way to cache bust effectively, this should be removed to enable users to view changes from CRUD immediately